### PR TITLE
Bump dependencies and fix inactivity tracking service usage

### DIFF
--- a/JukeBox.csproj
+++ b/JukeBox.csproj
@@ -8,9 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.7.2" />
-    <PackageReference Include="Lavalink4NET" Version="2.1.1-preview.6" />
-    <PackageReference Include="Lavalink4NET.Discord.NET" Version="2.1.1-preview.6" />
+    <PackageReference Include="Discord.Net" Version="3.10.0" />
+    <PackageReference Include="Lavalink4NET.Discord.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 

--- a/MusicService/LoopCommand.cs
+++ b/MusicService/LoopCommand.cs
@@ -50,9 +50,10 @@ public partial class MusicSlashCommands
             return;
         }
 
-        jukeBox.IsLooping = !jukeBox.IsLooping;
+        var isLooping = jukeBox.LoopMode is not PlayerLoopMode.None;
+        jukeBox.LoopMode = isLooping ? PlayerLoopMode.None : PlayerLoopMode.Track;
 
-        if (jukeBox.IsLooping)
+        if (isLooping)
         {
             embed.WithAuthor($"🔁 Vibe Looped by {Context.User.Username}")
                  .WithTitle($"JukeBox's vibe is now looping.")

--- a/MusicService/NowPlayingCommand.cs
+++ b/MusicService/NowPlayingCommand.cs
@@ -31,14 +31,15 @@ public partial class MusicSlashCommands
         }
 
         var vibe = jukeBox.CurrentTrack!;
+        var isLooping = jukeBox.LoopMode is not PlayerLoopMode.None;
 
-        embed.WithAuthor($"Current Vibe {(jukeBox.IsLooping ? "🔁" : "")}")
+        embed.WithAuthor($"Current Vibe {(isLooping ? "🔁" : "")}")
              .WithTitle(vibe.Title)
              .AddField("Channel", vibe.Author, true)
              .AddField("Timestamp", $"{jukeBox.Position.Position:d':'hh':'mm':'ss} / {vibe.Duration:d':'hh':'mm':'ss}", true)
              .AddField("Next Vibe", jukeBox.Queue.FirstOrDefault()?.Title ?? "-", true);
 
         await RespondAsync(embed: embed.Build());
-        await FollowupAsync(vibe.Source);
+        await FollowupAsync(vibe.Uri!.ToString());
     }
 }

--- a/MusicService/SkipCommand.cs
+++ b/MusicService/SkipCommand.cs
@@ -52,7 +52,7 @@ public partial class MusicSlashCommands
 
         var skippedVibe = jukeBox.CurrentTrack!;
 
-        jukeBox.IsLooping = false;
+        jukeBox.LoopMode = PlayerLoopMode.None;
 
         await jukeBox.SkipAsync();
 

--- a/Program.cs
+++ b/Program.cs
@@ -41,7 +41,7 @@ using (var scope = host.Services.CreateScope())
     client.Ready += async () =>
     {
         await scope.ServiceProvider.GetRequiredService<IAudioService>().InitializeAsync();
-        scope.ServiceProvider.GetRequiredService<InactivityTrackingService>().BeginTracking();
+        scope.ServiceProvider.GetRequiredService<InactivityTrackingService>();
         await slashCommands.RegisterCommandsGloballyAsync();
     };
 


### PR DESCRIPTION
**Commit Summary**

[chore: Bump dependencies](https://github.com/Juke-Duke/JukeBox/commit/75ffd5300a19dd6e941d7a222f64168ce367c3c3) 

Bump Discord.Net from 3.7.2 -> 3.10.0
Bump Lavalink4NET.Discord.NET 2.1.1-preview.6 -> 3.0.0
Remove dependency Lavalink4NET to as it is a transitive dependency of Lavalink4NET.Discord.NET and should not be explicitly referenced
 
refactor: Fix usage of obsolete members of Lavalink4NET 

Due the migration Lavalink4NET some obsolete members are used in the current source code. This commit adjusts accesses to use the new properties instead. Examples include usage of LavalinkPlayer#IsLooping which is now LavalinkPlayer#LoopMode and LavalinkTrack#Source which is now LavalinkTrack#Uri.ToString().

(squashed commit:)

fix: Fix loop mode logic in LoopCommand

Fixes an issue introduced in commit 1058bcc.
 
[fix: Remove call to inactivity tracking service to start tracking](dda162e)

The call to the tracking service to start tracking:
`scope.ServiceProvider.GetRequiredService<InactivityTrackingService>().BeginTracking();`
caused an exception to be thrown in the ready event handler of the discord client so that subsequent calls, e.g., here registering the method will not be executed.
The call is also redundant as the tracking is already enabled in the service collection construction when configuring the inactivity tracking options for the inactivity tracking service